### PR TITLE
The last minute addition of handling Editorial issues created problem…

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,11 @@ We would like to encourage the community at large to contribute to the maintenan
 The `index.html` file must be adapted. Apart from the obvious changes (setting the right title, reference to the Working Group, etc), the following attribute values must be set in the source:
 
 * `@data-githubrepo`, to be set on the `<head>` element to the repository name. For W3C repositories the name is usually of the form `w3c/@@@`, though there are groups that use a different “organization”.
-* `@data-erratalabel` must be set _on each_ top level `<section>` elements, except for the last one, within the `<main>` element. The value should be the label used in the errata repository for the specific document. The last section should be left as is, used by possible errata that are not explicitly assigned to a document.
+* If the WG has published several Recommendations:
+  * `@data-erratalabel` must be set _on each_ top level `<section>` elements, except for the last one, within the `<main>` element. The value should be the label used in the errata repository for the specific document among the published one.
+  * the last section should be left as is (i.e., with `data-nolabel`), and is used by errata that are not explicitly assigned to a document.
+* If the WG has published a single document:
+  * keep only one subsection within `<main>` and use `data-nolabel` for that one.
 
 If an editor's draft is maintained to reflect the text of the published Recommendation amended to include approved errata, you should add a link to this document in the `index.html` file.
 

--- a/assets/errata.js
+++ b/assets/errata.js
@@ -57,9 +57,9 @@ $(document).ready(function() {
             var dataset = $(this).prop('dataset');
             if( _.include(labels, dataset.erratalabel) ) {
                 if( _.include(labels, "Editorial") ) {
-                    subsect = $(this).children("section:first-of-type")
-                } else {
                     subsect = $(this).children("section:last-of-type")
+                } else {
+                    subsect = $(this).children("section:first-of-type")
                 }
                 display_issue(subsect, issue, comments, labels)
                 displayed = true;
@@ -70,9 +70,9 @@ $(document).ready(function() {
                 var dataset = $(this).prop('dataset');
                 if( dataset.nolabel !== undefined ) {
                     if( _.include(labels, "Editorial") ) {
-                        subsect = $(this).children("section:first-of-type")
-                    } else {
                         subsect = $(this).children("section:last-of-type")
+                    } else {
+                        subsect = $(this).children("section:first-of-type")
                     }
                     display_issue(subsect, issue, comments, labels)
                 }

--- a/index.html
+++ b/index.html
@@ -56,8 +56,8 @@
 
     <main>
       <!-- The data-erratalabel should include one label that filters the errata -->
-      <section data-erratalabel="@@@@">
-        <h1 class="todo">Open Errata on the “@@@@” Recommendation</h1>
+      <section data-erratalabel="@@@@1">
+        <h1 class="todo">Open Errata on the “@@@@1” Recommendation</h1>
         <dl>
             <dt>Latest Published Version:</dt>
             <dd><a class="todo" href="@@@@/">@@@@</a></dd>
@@ -66,9 +66,15 @@
             <dt>Latest Publication Date:</dt>
             <dd class="todo">@@@@ @@@@, @@@@</dd>
         </dl>
-      </section>
-      <section data-erratalabel="@@@@">
-        <h1 class="todo">Open Errata on the “@@@@” Recommendation</h1>
+        <section>
+          <h2>Substantial Issues</h2>
+        </section>
+        <section>
+          <h2>Editorial Issues</h2>
+        </section>
+  </section>
+      <section data-erratalabel="@@@@2">
+        <h1 class="todo">Open Errata on the “@@@@2” Recommendation</h1>
         <dl>
             <dt>Latest Published Version:</dt>
             <dd><a class="todo" href="@@@@/">@@@@</a></dd>
@@ -77,11 +83,23 @@
             <dt>Latest Publication Date:</dt>
             <dd class="todo">@@@@ @@@@, @@@@</dd>
         </dl>
+        <section>
+          <h2>Substantial Issues</h2>
+        </section>
+        <section>
+          <h2>Editorial Issues</h2>
+        </section>
       </section>
-      <!-- The section with the data-nolabel attributes collect those errate that are not displayed by any other
+      <!-- The section with the data-nolabel attributes collect those errata that are not displayed by any other
            label specific sections. -->
       <section data-nolabel>
         <h1>Other Errata, Not Assigned to a Specific Document</h1>
+        <section>
+          <h2>Substantial Issues</h2>
+        </section>
+        <section>
+          <h2>Editorial Issues</h2>
+        </section>
       </section>
     </main>
 

--- a/test.html
+++ b/test.html
@@ -65,12 +65,12 @@
             <dd>2015-12-17</dd>
         </dl>
         <section>
-            <h2>Editorial Errata</h2>
-        </section>
-        <section>
             <h2>Substantial Errata</h2>
         </section>
+        <section>
+          <h2>Editorial Errata</h2>
       </section>
+    </section>
       <section data-erratalabel="Metadata vocabulary document">
         <h1>Open Errata on the “Metadata vocabulary document” Recommendation</h1>
         <dl>
@@ -82,12 +82,12 @@
             <dd>2015-12-17</dd>
         </dl>
         <section>
-            <h2>Editorial Errata</h2>
-        </section>
-        <section>
             <h2>Substantial Errata</h2>
         </section>
+        <section>
+          <h2>Editorial Errata</h2>
       </section>
+    </section>
       <section data-erratalabel="CSV to RDF mapping">
         <h1>Open Errata on the “Generating RDF from Tabular Data on the Web” Recommendation</h1>
         <dl>
@@ -110,23 +110,23 @@
             <dd>2015-12-17</dd>
         </dl>
         <section>
-            <h2>Editorial Errata</h2>
-        </section>
-        <section>
             <h2>Substantial Errata</h2>
         </section>
+        <section>
+          <h2>Editorial Errata</h2>
       </section>
+    </section>
       <!-- The section with the data-nolabel attributes collect those errata that are not displayed by any other
            label specific sections. -->
       <section data-nolabel>
         <h1>Other Errata, Not Assigned to a Specific Document</h1>
         <section>
-            <h2>Editorial Errata</h2>
-        </section>
-        <section>
             <h2>Substantial Errata</h2>
         </section>
+        <section>
+          <h2>Editorial Errata</h2>
       </section>
+    </section>
     </main>
 
     <footer>


### PR DESCRIPTION
- the example file in the repository did not include the subsections for editorial and substantial issues (only the `test.html` file did) and that created problems
- the intention was to put the editorial errata to the end of the list, and that was not the case in the code or the in `test.html`
- the difference and proper use of the section labels for several documents were not clear