### PR TITLE
Adding an id to each item

### DIFF
--- a/assets/errata.js
+++ b/assets/errata.js
@@ -38,6 +38,7 @@ function display_issue(node, issue, comments, labels) {
     const display_labels = labels.filter((label) => label !== 'Errata').join(', ');
     const div = document.createElement('div');
     div.className = 'issue';
+    div.id = `Erratum_${issue.number}`;
     node.append(div);
     div.innerHTML = `<h3>"${issue.title}"</h3>`;
 


### PR DESCRIPTION
This is to fix #20: it adds the `@id` value of the form `Erratum_ISSUENUMBER` to the `<div>` element enclosing the erratum.

However... not sure it behaves exactly as expected. The URL of the form `https://..../errata.html#Erratum_1234` is valid, but it is, sort of, too late for the browser. Meaning that if one uses that URL in the browser's address bar, then the browser only goes to the top level, and does not automatically go to the specific item. This is probably because the ID is put there by the script after the full page is rendered, and so tehre is some sort of a timing issue. I am not sure how to solve that, ideas are welcome...

Cc @gkellogg

