### PR TITLE
Adopting the RCH WG Review comments

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,11 @@
         <p>Errata are introduced and stored in the <a class="todo" href="https://github.com/w3c/@@@@/issues/">issue list of the group‘s GitHub repository</a>. The workflow to add a new erratum is as follows:</p>
         <ol>
           <li>An issue is raised for a possible erratum. The label of the issue SHOULD be set to “<code>ErratumRaised</code>”.
-            It is okay for an erratum to have several labels.</li>
+            It SHOULD also include the label corresponding to the document on which the erratum is raised, e.g., “<code
+              class="todo">@@@@</code>” or “<code class="todo">@@@@</code>”. (Please, consult the <a class="todo"
+              href="https://github.com/w3c/@@@@/labels">list of available labels</a>.) It is okay for an erratum to have several
+            labels. In some, exceptional, cases, i.e., when the erratum is very general, it is also acceptable not to have a
+            reference to a document.</li>
           <li>Issues labeled as “<code>Editorial</code>” are displayed separately, to make it easier to differentiate editorial
             errata from substantive ones.</li>
           <li>The community discusses the issue. If it is accepted as a genuine erratum, the label “<code>Errata</code>” is

--- a/index.html
+++ b/index.html
@@ -34,15 +34,23 @@
       <section data-notoc>
         <h1>How to Submit an Erratum?</h1>
         <p>Errata are introduced and stored in the <a class="todo" href="https://github.com/w3c/@@@@/issues/">issue list of the group‘s GitHub repository</a>. The workflow to add a new erratum is as follows:</p>
-        <ul>
-           <li>An issue is raised for a possible erratum. The label of the issue SHOULD be set to “<code>ErratumRaised</code>”. It SHOULD also include the label corresponding to the document on which the erratum is raised, e.g., “<code class="todo">@@@@</code>” or “<code class="todo">@@@@</code>”. (Please, consult the <a class="todo" href="https://github.com/w3c/@@@@/labels">list of available labels</a>.) It is o.k. for an erratum to have several labels. In some, exceptional, cases, i.e., when the erratum is very general, it is also acceptable not to have a reference to a document.</li>
-           <li>Issues labeled as “<code>Editorial</code>” are displayed separately, to make it easier to differentiate editorial errata from substantial ones.</li>
-          <li>The community discusses the issue. If it is accepted as a genuine erratum, the label “<code>Errata</code>” is added to the entry and the “<code>ErratumRaised</code>” label should be removed. Additionally, a new comment on the issue MAY be added, beginning with the word "Summary:" (if such a summary is useful based on the discussion).</li>
-          <li>All issues, labeled by “<code>Errata</code>”, are displayed in this report, whether they are opened or closed. Their status is added to the report on the individual errata.</li>
+        <ol>
+          <li>An issue is raised for a possible erratum. The label of the issue SHOULD be set to “<code>ErratumRaised</code>”.
+            It is okay for an erratum to have several labels.</li>
+          <li>Issues labeled as “<code>Editorial</code>” are displayed separately, to make it easier to differentiate editorial
+            errata from substantive ones.</li>
+          <li>The community discusses the issue. If it is accepted as a genuine erratum, the label “<code>Errata</code>” is
+            added to the entry and the “<code>ErratumRaised</code>” label removed. A new comment on the issue MAY also be added,
+            beginning with the word "Summary:" (if such a summary is useful, based on the discussion).</li>
+          <li>All issues labeled as “<code>Errata</code>” are displayed in this report, whether they are open or closed. Their
+            status is added to the report on the individual errata.</li>
           <li>If the community rejects the issue as an erratum, the issue should be closed.</li>
-          <li>Each errata may be labelled as “<code>Editorial</code>”; editorial errata are listed separately from the substantial ones.</li>
-          <li>ALL substantive errata are generally expected to have corresponding test(s) (such as a pull request in <a href='https://github.com/web-platforms-tests/wpt'>web-platforms-tests</a>)), either in the form of new tests or modifications to existing tests, or must include the rationale for why test updates are not required for the erratum.</li>
-      </ul>
+          <li>Each erratum may be labelled as “<code>Editorial</code>”; editorial errata are listed separately from the
+            substantive ones.</li>
+          <li>ALL substantive errata are expected to have corresponding test(s), in the form of either new tests or
+            modifications to existing tests, or must include a rationale explaining why test updates are not required for the
+            erratum.</li>
+        </ol>
 
         <p>This report contains a reference to all open issues with the label <code>Errata</code>, displayed in the sections below. Each section collects the issues for a specific document, with a separate section for the issues not assigned to any.</p>
 

--- a/index_single.html
+++ b/index_single.html
@@ -34,15 +34,24 @@
       <section data-notoc>
         <h1>How to Submit an Erratum?</h1>
         <p>Errata are introduced and stored in the <a class="todo" href="https://github.com/w3c/@@@@/issues/">issue list of the document‘s GitHub repository</a>. The workflow to add a new erratum is as follows:</p>
-        <ul>
-           <li>An issue is raised for a possible erratum. The label of the issue SHOULD be set to “<code>ErratumRaised</code>”. It is o.k. for an erratum to have several labels.</li>
-           <li>Issues labeled as “<code>Editorial</code>” are displayed separately, to make it easier to differentiate editorial errata from substantial ones.</li>
-          <li>The community discusses the issue. If it is accepted as a genuine erratum, the label “<code>Errata</code>” is added to the entry and the “<code>ErratumRaised</code>” label should be removed. Additionally, a new comment on the issue MAY be added, beginning with the word "Summary:" (if such a summary is useful based on the discussion).</li>
-          <li>All issues, labeled by “<code>Errata</code>”, are displayed in this report, whether they are opened or closed. Their status is added to the report on the individual errata.</li>
+        
+        <ol>
+          <li>An issue is raised for a possible erratum. The label of the issue SHOULD be set to “<code>ErratumRaised</code>”.
+            It is okay for an erratum to have several labels.</li>
+          <li>Issues labeled as “<code>Editorial</code>” are displayed separately, to make it easier to differentiate editorial
+            errata from substantive ones.</li>
+          <li>The community discusses the issue. If it is accepted as a genuine erratum, the label “<code>Errata</code>” is
+            added to the entry and the “<code>ErratumRaised</code>” label removed. A new comment on the issue MAY also be added,
+            beginning with the word "Summary:" (if such a summary is useful, based on the discussion).</li>
+          <li>All issues labeled as “<code>Errata</code>” are displayed in this report, whether they are open or closed. Their
+            status is added to the report on the individual errata.</li>
           <li>If the community rejects the issue as an erratum, the issue should be closed.</li>
-          <li>Each errata may be labelled as “<code>Editorial</code>”; editorial errata are listed separately from the substantial ones.</li>
-          <li>ALL substantive errata are generally expected to have corresponding test(s), either in the form of new tests or modifications to existing tests, or must include the rationale for why test updates are not required for the erratum.</li>
-        </ul>
+          <li>Each erratum may be labelled as “<code>Editorial</code>”; editorial errata are listed separately from the
+            substantive ones.</li>
+          <li>ALL substantive errata are expected to have corresponding test(s), in the form of either new tests or
+            modifications to existing tests, or must include a rationale explaining why test updates are not required for the
+            erratum.</li>
+        </ol>
 
         <p>If you have problems following this process, but you want nevertheless to report an error, you can also contact the staff contact of the Working Group, <a class="todo" href="mailto:@@@@@w3.org">@@@@</a>.</p>
       </section>


### PR DESCRIPTION
While installing the script for the RDF Canonicalization Recommendation at the W3C RCH Working Group, the introductory text got some editorial improvements. This PR adopts the improvements to the "core" script for the other Working Groups to use